### PR TITLE
Add Notes nav section and e2e search/personalization subpage

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,2 +1,4 @@
 # main links links
 main:
+  - title: "Notes"
+    url: /notes/

--- a/_pages/notes-how-to-design-e2e-search-personalization.md
+++ b/_pages/notes-how-to-design-e2e-search-personalization.md
@@ -1,0 +1,56 @@
+---
+title: "How to Design End-to-End Search/Personalization"
+permalink: /notes/how-to-design-e2e-search-personalization/
+excerpt: "A practical framework for designing an end-to-end search and personalization system"
+author_profile: true
+---
+
+This note outlines a practical approach to designing an end-to-end search and personalization system.
+
+## 1) Define goals and constraints
+
+- Clarify product goals (e.g., relevance, conversion, engagement, retention).
+- Define hard constraints (latency, privacy, explainability, fairness).
+- Align on target metrics before model development.
+
+## 2) Build the serving architecture
+
+- **Candidate generation:** retrieve a high-recall set quickly (lexical + vector + behavioral retrieval).
+- **Ranking:** score candidates with personalized features and model predictions.
+- **Re-ranking/business rules:** enforce diversity, freshness, policy, and inventory constraints.
+- **Response assembly:** construct final results with metadata for UI and analytics.
+
+## 3) Design features and data flows
+
+- User features: long-term preferences, short-term intent, session behavior.
+- Item/query features: content embeddings, popularity, quality signals.
+- Context features: device, locale, time, channel, referrer.
+- Create robust online/offline feature pipelines with consistent definitions.
+
+## 4) Personalization strategy
+
+- Blend global relevance and user-specific signals to avoid overfitting.
+- Use cold-start fallbacks for new users/items.
+- Add exploration mechanisms for discovery and catalog coverage.
+
+## 5) Evaluation and experimentation
+
+- Offline: NDCG, MRR, Recall@K, calibration, slice-level diagnostics.
+- Online: A/B testing with guardrails for latency, zero-result rate, and user experience.
+- Monitor drift and retrain cadence based on data/traffic changes.
+
+## 6) Operational readiness
+
+- Track end-to-end latency budgets by stage.
+- Add observability for query intent, ranking features, and failure modes.
+- Build safe rollback plans and progressive rollouts.
+
+## 7) Governance
+
+- Respect privacy and consent boundaries.
+- Audit for fairness across key cohorts.
+- Document model behavior and intervention policies.
+
+---
+
+If useful, I can also add diagrams for the architecture and a checklist template for launch readiness.

--- a/_pages/notes.md
+++ b/_pages/notes.md
@@ -1,0 +1,12 @@
+---
+title: "Notes"
+permalink: /notes/
+excerpt: "Notes and write-ups"
+author_profile: true
+---
+
+Welcome to the Notes section.
+
+## Subpages
+
+- [How to Design End-to-End Search/Personalization](/notes/how-to-design-e2e-search-personalization/)


### PR DESCRIPTION
### Motivation

- Provide a top-level Notes section on the homepage to surface short write-ups and reference material.
- Add a focused subpage that documents a practical, end-to-end design for search and personalization so the content is discoverable from the site nav.

### Description

- Added a new navigation entry in `_data/navigation.yml` with `title: "Notes"` and `url: /notes/` so it appears in the masthead. 
- Created a `Notes` landing page at `_pages/notes.md` with a link to the new subpage. 
- Added the detailed subpage `_pages/notes-how-to-design-e2e-search-personalization.md` that outlines goals, architecture, features, evaluation, operations, and governance for e2e search/personalization. 
- Changes were committed on the branch (commit message: "Add Notes section and e2e search/personalization note").

### Testing

- Parsed `_data/navigation.yml` using Ruby YAML (`ruby -e 'require "yaml"; YAML.load_file("_data/navigation.yml")'`) and the file loaded successfully. 
- Verified both new pages contain valid front matter using a small Python check that confirmed each file begins with a front-matter block. 
- Attempted `bundle exec jekyll build` but the `jekyll` executable was not available in the environment so a full site build could not be completed. 
- Attempted `bundle install` to install dependencies but gem fetch to `rubygems.org` returned HTTP 403, and a Playwright screenshot attempt failed because no local site server was running, so runtime validation (site build / local preview) could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927c6dec28832fb19a7015911ecb6d)